### PR TITLE
Add parameter sshd_root for control warnings about ssh root login

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ Ignore check errors forced by SAP DAA.
 
 Ignore check errors forced by SAP ICM.
 
+####`sshd_root`
+
+Surpress warning if root login is permit.
+Should be the same as PermitRootLogin in sshd_config
+
 
 ##Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,12 +27,17 @@
 # [*sapICM*]
 #   Ignore check errors forced by SAP ICM
 #
+# [*sshd_root*]
+#   Surpress warning if root login is permit.
+#   Should be the same as PermitRootLogin in sshd_config
+#
 # === Variables
 #
 # === Examples
 #
 #  class { '::rkhunter':
-#    tftp => true
+#    tftp => true,
+#    sshd_root => 'without-password'
 #  }
 #
 # === Authors
@@ -51,6 +56,7 @@ class rkhunter (
   $sapDAA        = $rkhunter::params::sapDAA,
   $sapICM        = $rkhunter::params::sapICM,
   $disable_tests = $rkhunter::params::disable_tests,
+  $sshd_root     = $rkhunter::params::sshd_root,
 ) inherits rkhunter::params {
   # Require class yum to have the relevant repositories in place
   require yum

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,5 +42,6 @@ class rkhunter::params {
   $oracleXE = false
   $sapDAA = false
   $sapICM = false
+  $sshd_root = 'unset'
   $disable_tests = ['suspscan', 'hidden_procs', 'deleted_files', 'packet_cap_apps', 'apps']
 }

--- a/templates/etc/rkhunter.conf.erb
+++ b/templates/etc/rkhunter.conf.erb
@@ -314,7 +314,7 @@ AUTO_X_DETECT=1
 # The default value is 'no'.
 #
 #ALLOW_SSH_ROOT_USER=no
-ALLOW_SSH_ROOT_USER=unset
+ALLOW_SSH_ROOT_USER=<%= @sshd_root %>
 
 #
 # Set this option to '1' to allow the use of the SSH-1 protocol, but note


### PR DESCRIPTION
On Centos 6.5 rkhunter with ALLOW_SSH_ROOT_USER=unset still generate warnings
