### PR TITLE
Added $repo_class and $web_cmd parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Ignore check errors forced by SAPDB/MaxDB.
 Surpress warning if root login is permit.
 Should be the same as PermitRootLogin in sshd_config
 
+####`repo_class`
+
+Class name needed to setup repositories. Can be undefined.
+
+####`web_cmd`
+
+Command used to pull files from the internet (ie: when --update is specified)
 
 ##Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,13 @@
 #   Surpress warning if root login is permit.
 #   Should be the same as PermitRootLogin in sshd_config
 #
+# [*web_cmd*]
+#   Command used to retrieve files from the internet (ie: while
+#   running with --update)
+#
+# [*repo_class*]
+#   If defined, it's the name of the class required to setup the repos
+#
 # === Variables
 #
 # === Examples
@@ -62,12 +69,18 @@ class rkhunter (
   $oracleXE      = $rkhunter::params::oracleXE,
   $sapDAA        = $rkhunter::params::sapDAA,
   $sapICM        = $rkhunter::params::sapICM,
-  $sapDB        = $rkhunter::params::sapDB,
+  $sapDB         = $rkhunter::params::sapDB,
   $disable_tests = $rkhunter::params::disable_tests,
   $sshd_root     = $rkhunter::params::sshd_root,
+  $repo_class    = 'yum',
+  $web_cmd       = undef,
 ) inherits rkhunter::params {
-  # Require class yum to have the relevant repositories in place
-  require yum
+
+  if $repo_class and $repo_class!='' {
+    # Require repo class to have the relevant repositories in place
+    class {$repo_class:}
+    Class[$repo_class] -> Class['rkhunter']
+  }
 
   # Start workflow
   if $rkhunter::params::linux {

--- a/templates/etc/rkhunter.conf.erb
+++ b/templates/etc/rkhunter.conf.erb
@@ -1175,6 +1175,10 @@ RTKT_FILE_WHITELIST=/var/log/pki/pki-tomcat/ca/system
 # This option has no default value.
 #
 #WEB_CMD=""
+<% if @web_cmd and @web_cmd != "" -%>
+# Contrary to what the examples show it appears that the WEB_CMD var should be without quotes
+WEB_CMD=<%= @web_cmd %>
+<% end -%>
 
 #
 # Set the following option to '1' if locking is to be used when rkhunter runs.


### PR DESCRIPTION
About $repo_class. Requiring `yum` class should be optional and certain
companies already have (custom) classes that do that. In such environments
it's useful to allow the user to choose which class to use. This parameter
can be `undef` (in this case no class is included).

About $web_cmd. Some companies do not allow servers to access directly
the Internet but they require a proxy. Being able to define the $WEB_CMD
config variable helps in this kind of situation.