### PR TITLE
added lf to end of template file

### DIFF
--- a/templates/sysconfig/rkhunter.erb
+++ b/templates/sysconfig/rkhunter.erb
@@ -13,3 +13,4 @@
 MAILTO=<%= scope.lookupvar('rkhunter::root_email') %>
 DIAG_SCAN=no
 CRON_DAILY_RUN=<%= scope.lookupvar('rkhunter::cron_daily_run') %>
+


### PR DESCRIPTION
It is best practice that linux files end with a new line. I have found that if not, tools like sed,awk do not work well. Apparently puppet too.

On a Debian stretch system the last line was not getting added to the configuration.