### PR TITLE
Adding ALLOW for an udev rule (seen on Ubuntu)

### DIFF
--- a/templates/etc/rkhunter.conf.erb
+++ b/templates/etc/rkhunter.conf.erb
@@ -1500,6 +1500,7 @@ ALLOWHIDDENDIR=/dev/.udev
 ALLOWDEVFILE=/dev/.udev/uevent_seqnum
 ALLOWDEVFILE=/dev/.blkid.tab
 ALLOWDEVFILE=/dev/.initramfs
+ALLOWDEVFILE=/dev/.udev/rules.d/root.rules
 <% end -%>
 <% if scope.lookupvar('::osfamily') == 'Gentoo' then -%>
 SCRIPTWHITELIST=/usr/bin/ldd


### PR DESCRIPTION
To avoid message `/dev/.udev/rules.d/root.rules: ASCII text`