### PR TITLE
Adds rkhunter::whitelist define class

### DIFF
--- a/manifests/whitelist.pp
+++ b/manifests/whitelist.pp
@@ -1,0 +1,13 @@
+# This define class can be used to whitelist specific stuff on rkhunter
+define rkhunter::whitelist (
+  Array $list = [],
+  String $filename = "${rkhunter::params::config_rkhunter_script_directory}/whitelist.conf",
+) {
+  file { $filename:
+    ensure  => 'present',
+    content => join(concat(['# Managed by Puppet !'], $list), "\n"),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+}


### PR DESCRIPTION
This will add a new define class in case someone needs to whitelist specific things
The class take an Array and a filename as arguments. Here is an example:
```ruby
rkhunter::whitelist { 'katello':
  list           => ['ALLOWDEVFILE=/dev/shm/squid*shm',
                     'ALLOWIPCPROC=/usr/bin/postgres',
                     'XINETD_ALLOWED_SVC=/etc/xinetd.d/tftp'],
  filename       => '/etc/rkhunter.d/my_katello_whitelist.conf'
}
```