### PR TITLE
fix default value in ALLOW_SSH_PROT_V1

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,7 +96,7 @@ class rkhunter::params {
   $sap_icm                               = false
   $sap_db                                = false
   $sshd_root                             = 'unset'
-  $ssh_prot_v1                           = 2
+  $ssh_prot_v1                           = 0
   $web_cmd                               = 'unset'
   $disable_tests                         = ['suspscan', 'hidden_procs', 'deleted_files', 'packet_cap_apps', 'apps']
   $cron_daily_run                        = 'y'


### PR DESCRIPTION
From the default conf file: 

 Set this option to '1' to allow the use of the SSH-1 protocol, but note
 that theoretically it is weaker, and therefore less secure, than the
 SSH-2 protocol. Do not modify this option unless you have good reasons
 to use the SSH-1 protocol (for instance for AFS token passing or Kerberos4
 authentication). If the 'Protocol' option has not been set in the SSH
 configuration file, then a value of '2' may be set here in order to
 suppress a warning message. A value of '0' indicates that the use of
 SSH-1 is not allowed.

 The default value is '0'.

ALLOW_SSH_PROT_V1=0