### PR TITLE
MAIL variable is different on Debian/Archlinux

### DIFF
--- a/templates/sysconfig/rkhunter.erb
+++ b/templates/sysconfig/rkhunter.erb
@@ -14,7 +14,7 @@
 #            yes - perform detailed report scan
 #                  (includes application check)
 <% if @osfamily == 'Debian' || @osfamily == 'Archlinux' -%>
-REPORT_EMAIL=<%= scope['rkhunter::root_email'] -%>
+REPORT_EMAIL=<%= scope['rkhunter::root_email'] %>
 <% else -%>
 MAILTO=<%= scope['rkhunter::root_email'] %>
 <% end -%>

--- a/templates/sysconfig/rkhunter.erb
+++ b/templates/sysconfig/rkhunter.erb
@@ -5,12 +5,19 @@
 #
 # managed by Puppet, local changes will be overwritten
 #
+<% if @osfamily == 'Debian' || @osfamily == 'Archlinux' -%>
+# REPORT_EMAIL= <email address to send scan report>
+<% else -%>
 #    MAILTO= <email address to send scan report>
+<% end -%>
 # DIAG_SCAN= no  - perform  normal  report scan
 #            yes - perform detailed report scan
 #                  (includes application check)
-
+<% if @osfamily == 'Debian' || @osfamily == 'Archlinux' -%>
+REPORT_EMAIL=<%= scope['rkhunter::root_email'] -%>
+<% else -%>
 MAILTO=<%= scope['rkhunter::root_email'] %>
+<% end -%>
 DIAG_SCAN=no
 CRON_DAILY_RUN=<%= scope['rkhunter::cron_daily_run'] %>
 CRON_DB_UPDATE=<%= scope['rkhunter::cron_db_update'] %>


### PR DESCRIPTION
When I had a syntax error in a local config file I would never get a report of error. I finally discovered that the daily cron job for Debian and Archlinux uses a different VARIABLE name for the report email. This PR will fix that issue.

vagrant@centos7 ~]$ grep MAIL /etc/cron.daily/rkhunter 
    MAILTO=root@localhost
         /bin/cat $TMPFILE1 | /bin/mail -s "rkhunter Daily Run on $(hostname)" $MAILTO
         
vagrant@bionic:~$ grep MAIL /etc/cron.daily/rkhunter
        if [ -s "$OUTFILE" -a -n "$REPORT_EMAIL" ]; then
            echo "To: $REPORT_EMAIL"
          ) | /usr/sbin/sendmail $REPORT_EMAIL
